### PR TITLE
use 65-byte compressed signature format

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ ArrayBuffer { byteLength: 20 }
 '9c1185a5c5e9fc54612808977ee8f548b2258d31'
 ```
 
-### crypto.SecretKey
+### crypto.PrivateKey
 
 Provides operations over Steemit secp256k1-based ECC private keys.
 ```
-> secretKey = crypto.SecretKey.from('5JCDRqLdyX4W7tscyzyxav8EaqABSVAWLvfi7rdqMKJneqqwQGt')
-SecretKey { getPublicKey: [Function], sign: [Function] }
+> secretKey = crypto.PrivateKey.from('5JCDRqLdyX4W7tscyzyxav8EaqABSVAWLvfi7rdqMKJneqqwQGt')
+PrivateKey { getPublicKey: [Function], sign: [Function] }
 > secretKey.getPublicKey().toString()
 'STM5pZ15FDVAvNKW3saTJchWmSSmYtEvA6aKiXwDtCq2JRZV9KtR9'
 > secretSig = secretKey.sign(new Uint8Array(32).buffer)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "steem-crypto",
+  "name": "@steemit/libcrypto",
   "version": "1.0.0",
   "description": "Common javascript cryptographic utilities. Based on sjcl.",
   "main": "lib/crypto.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,18 +1,18 @@
 /* eslint-env node */
 
-exports.run = buildSjcl;
+exports.run = build;
 
 var config = require('./config');
 var file = require('./lib/file');
 
 if (require.main === module) {
-  buildSjcl().catch(function(error) {
+  build().catch(function(error) {
     console.error(error); // eslint-disable-line no-console
     process.exit(1);
   });
 }
 
-function buildSjcl() {
+function build() {
   return file
     .mkdirP('lib')
     .then(function() {

--- a/scripts/dist.js
+++ b/scripts/dist.js
@@ -10,7 +10,7 @@ var file = require('./lib/file');
 var sets = [
   {
     out: 'steem-crypto',
-    files: ['lib/sjcl.js', 'lib/crypto']
+    files: ['lib/sjcl.js', 'lib/crypto.js']
   },
   {
     out: 'steemit.tiny',

--- a/src/codecSteemit.js
+++ b/src/codecSteemit.js
@@ -1,23 +1,32 @@
 /* global sjcl */
 sjcl.codec.steemit = {
   ROLES: ['owner', 'memo', 'active', 'posting'],
-  PUB_KEY_EVEN: 0x2,
-  PUB_KEY_ODD: 0x3,
-  HEADER: 0x80,
+  MAINNET: {
+    pubHeader: 0x0,
+    privHeader: 0x80,
+    pubPrefix: 'STM' 
+  },
+  TESTNET: {
+    pubHeader: 0x0,
+    privHeader: 0x80,
+    pubPrefix: 'TST' 
+  },
   keyChecksum: function(bits) {
     return sjcl.bitArray.bitSlice(sjcl.hash.ripemd160.hash(bits), 0, 32);
   },
 
-  keysFromPassword: function(account, password) {
+  keysFromPassword: function(account, password, net) {
+    net = net || sjcl.codec.steemit.MAINNET;
+
     var keyPairs = {};
-    var curve = sjcl.ecc.curves.k256;
+    var CURVE = sjcl.ecc.curves.k256;
     for (var i = 0; i < sjcl.codec.steemit.ROLES.length; i++) {
       var role = sjcl.codec.steemit.ROLES[i];
       var seed = account + role + password;
       var secret = sjcl.bn.fromBits(
         sjcl.hash.sha256.hash(sjcl.codec.utf8String.toBits(seed))
       );
-      keyPairs[role] = sjcl.ecc.ecdsa.generateKeys(curve, 0, secret);
+      keyPairs[role] = sjcl.ecc.ecdsa.generateKeys(CURVE, 0, secret);
     }
     return keyPairs;
   },
@@ -115,62 +124,34 @@ sjcl.codec.steemit = {
     throw new Error('public key was unrecoverable');
   },
 
-  serializeSecretKey: function(key, header) {
-    return sjcl.codec.base58Check.fromBits(
-      header || sjcl.codec.steemit.HEADER,
-      key.get()
-    );
-  },
+  serializePublicKey: function(key, net) {
+    net = net || sjcl.codec.steemit.MAINNET;
 
-  deserializeSecretKey: function(wif, header) {
-    header = header || sjcl.codec.steemit.HEADER;
-    var curve = sjcl.ecc.curves.k256;
-    var payload = sjcl.codec.base58Check.toBits(wif);
-    var headerByte = sjcl.bitArray.extract(payload, 0, 8);
-    if (headerByte !== header) {
-      throw new Error(
-        'secret key has invalid header: wanted 0x' +
-          header.toString(16) +
-          ', got 0x' +
-          headerByte.toString(16)
-      );
-    }
-
-    var keyBits = sjcl.bitArray.bitSlice(payload, 8);
-    return new sjcl.ecc.ecdsa.secretKey(curve, sjcl.bn.fromBits(keyBits));
-  },
-
-  serializePublicKey: function(key) {
     var point = key.get();
-    var pubKeyHeader;
+    var header = net.pubHeader;
 
-    // the public key header is 0x3 if X is odd, 0x2 if even
-    if (
-      sjcl.bn
-        .fromBits(point.y)
-        .mod(2)
-        .equals(1)
-    ) {
-      pubKeyHeader = sjcl.codec.steemit.PUB_KEY_ODD;
+    // the public key header sets 0x3 if X is odd, 0x2 if even
+    if (sjcl.bn.fromBits(point.y).limbs[0] & 0x1) {
+      header |= 0x3;
     } else {
-      pubKeyHeader = sjcl.codec.steemit.PUB_KEY_EVEN;
+      header |= 0x2;
     }
-    return (
-      'STM' +
+    return net.pubPrefix + 
       sjcl.codec.base58Check.fromBits(
-        pubKeyHeader,
+        header,
         point.x,
         sjcl.codec.steemit.keyChecksum
       )
-    );
+    ;
   },
 
-  deserializePublicKey: function(pubKey) {
+  deserializePublicKey: function(pubKey, net) {
+    net = net || sjcl.codec.steemit.MAINNET;
     var CURVE = sjcl.ecc.curves.k256;
 
-    if (pubKey.slice(0, 3) !== 'STM') {
+    if (pubKey.indexOf(net.pubPrefix) !== 0) {
       throw new Error(
-        'Public key is not in Steemit format, it should begin with "STM"'
+        'Public key is not in correct format, it should begin with "' + net.pubPrefix + '"'
       );
     }
 
@@ -180,9 +161,11 @@ sjcl.codec.steemit = {
     );
     var headerByte = sjcl.bitArray.extract(payload, 0, 8);
     var isOdd = headerByte == 0x3;
-    if (headerByte !== 0x3 && headerByte !== 0x2) {
+    if (headerByte & net.pubHeader !== net.pubHeader) {
+      throw new Error('public key has invalid header');
+    } else if (headerByte & 0x3 === 0 && headerByte & 0x2 === 0) {
       throw new Error(
-        'public key has invalid header: wanted 0x2 or 0x3, got 0x' +
+        'public key has invalid header: should set 0x2 or 0x3, but got 0x' +
           headerByte.toString(16)
       );
     }
@@ -192,6 +175,32 @@ sjcl.codec.steemit = {
     var y = sjcl.codec.steemit._yFromX(x, isOdd);
 
     return new sjcl.ecc.ecdsa.publicKey(CURVE, new sjcl.ecc.point(CURVE, x, y));
+  },
+
+  serializePrivateKey: function(key, net) {
+    net = net || sjcl.codec.steemit.MAINNET;
+    return sjcl.codec.base58Check.fromBits(
+      net.privHeader,
+      key.get()
+    );
+  },
+
+  deserializePrivateKey: function(wif, header) {
+    header = header || sjcl.codec.steemit.MAINNET.privHeader;
+    var curve = sjcl.ecc.curves.k256;
+    var payload = sjcl.codec.base58Check.toBits(wif);
+    var headerByte = sjcl.bitArray.extract(payload, 0, 8);
+    if (headerByte !== header) {
+      throw new Error(
+        'private key has invalid header: wanted 0x' +
+          header.toString(16) +
+          ', got 0x' +
+          headerByte.toString(16)
+      );
+    }
+
+    var keyBits = sjcl.bitArray.bitSlice(payload, 8);
+    return new sjcl.ecc.ecdsa.secretKey(curve, sjcl.bn.fromBits(keyBits));
   },
 
   _yFromX: function(x, shouldBeOdd) {

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -9,7 +9,7 @@
     factory((root.steemit.crypto = {}));
   }
 })(typeof self !== 'undefined' ? self : this, function(exports) {
-  exports.SecretKey = SecretKey;
+  exports.PrivateKey = PrivateKey;
   exports.PublicKey = PublicKey;
   exports.generateKeys = generateKeys;
   exports.keysFromPassword = keysFromPassword;
@@ -26,7 +26,7 @@
 
   exports.sjcl = sjcl;
 
-  function SecretKey(sec, pub) {
+  function PrivateKey(sec, pub) {
     // we deliberately avoid exposing secret key material on the instance.
     // this is paranoid and probably doesn't protect against a determined
     // attack, but why make things easy?
@@ -46,8 +46,8 @@
     };
   }
 
-  SecretKey.from = function(wif, header) {
-    return new SecretKey(sjcl.codec.steemit.deserializeSecretKey(wif, header));
+  PrivateKey.from = function(wif, header) {
+    return new PrivateKey(sjcl.codec.steemit.deserializePrivateKey(wif, header));
   };
 
   function PublicKey(pub) {
@@ -119,7 +119,7 @@
 
   function serializePair(k) {
     return {
-      secret: sjcl.codec.steemit.serializeSecretKey(k.sec),
+      secret: sjcl.codec.steemit.serializePrivateKey(k.sec),
       public: sjcl.codec.steemit.serializePublicKey(k.pub)
     };
   }

--- a/test/codecSteemit.test.js
+++ b/test/codecSteemit.test.js
@@ -5,7 +5,7 @@ new sjcl.test.TestCase("steemit signature test vectors", function(cb) {
 
   sjcl.test.vector.steemitsig.forEach(function(fixture) {
   
-    var secretKey = sjcl.codec.steemit.deserializeSecretKey(fixture.secretKey);
+    var secretKey = sjcl.codec.steemit.deserializePrivateKey(fixture.secretKey);
     var publicKey = sjcl.codec.steemit.deserializePublicKey(fixture.publicKey);
 
     fixture.signatures.forEach(function(signature) {
@@ -47,7 +47,7 @@ new sjcl.test.TestCase("steemit signature test vectors", function(cb) {
 new sjcl.test.TestCase("steemit signature core functionality", function(cb) {
    
   var keys = {
-    sec: sjcl.codec.steemit.deserializeSecretKey("5JamTPvZyQsHf8c2pbN92F1gUY3sJkpW3ZJFzdmfbAJPAXT5aw3"),
+    sec: sjcl.codec.steemit.deserializePrivateKey("5JamTPvZyQsHf8c2pbN92F1gUY3sJkpW3ZJFzdmfbAJPAXT5aw3"),
     pub: sjcl.codec.steemit.deserializePublicKey("STM5SKxjN1YdrFLgoPcp9KteUmNVdgE8DpTPC9sF6jbjVqP9d2Utq")
   };
  
@@ -79,7 +79,7 @@ new sjcl.test.TestCase("steemit key codec tests", function (cb) {
       testValue.password
     );
 
-    var serializedSec = sjcl.codec.steemit.serializeSecretKey(keys[testValue.role].sec);
+    var serializedSec = sjcl.codec.steemit.serializePrivateKey(keys[testValue.role].sec);
     var serializedPub = sjcl.codec.steemit.serializePublicKey(keys[testValue.role].pub);
 
     this.require(testValue.sec == serializedSec, 'secret key: generated ' + serializedSec + ', expected ' + testValue.sec);
@@ -103,10 +103,10 @@ new sjcl.test.TestCase("steemit key codec tests", function (cb) {
     );
 
     // on deserialization the secret key should be the same
-    var deserializedSecretKey = sjcl.codec.steemit.deserializeSecretKey(serializedSec);
+    var deserializedPrivateKey = sjcl.codec.steemit.deserializePrivateKey(serializedSec);
     this.require(
       sjcl.bitArray.equal(
-        deserializedSecretKey.get(),
+        deserializedPrivateKey.get(),
         keys[testValue.role].sec.get()
       ),
       "original and deserialized secret keys are identical"

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -23,7 +23,7 @@ test('crypto.generateKeys', function(t) {
 
   t.equal(keys.public.slice(0, 3), 'STM', 'generated public key is in steem format');
 
-  var sec = crypto.SecretKey.from(keys.secret);
+  var sec = crypto.PrivateKey.from(keys.secret);
   var pub = crypto.PublicKey.from(keys.public);
 
   var sig = sec.sign(testHash);
@@ -65,9 +65,10 @@ test('crypto.keysFromPassword', function(t) {
 });
 
 
-test('crypto.SecretKey', function(t) {
-  var sec = crypto.SecretKey.from('5JamTPvZyQsHf8c2pbN92F1gUY3sJkpW3ZJFzdmfbAJPAXT5aw3');
+test('crypto.PrivateKey', function(t) {
+  var sec = crypto.PrivateKey.from('5JamTPvZyQsHf8c2pbN92F1gUY3sJkpW3ZJFzdmfbAJPAXT5aw3');
   var pub = sec.getPublicKey();
+
   t.equal(
     pub.toString(),
     'STM5SKxjN1YdrFLgoPcp9KteUmNVdgE8DpTPC9sF6jbjVqP9d2Utq',
@@ -84,7 +85,7 @@ test('crypto.SecretKey', function(t) {
 });
 
 test('crypto.PublicKey', function(t) {
-  var sec = crypto.SecretKey.from('5JamTPvZyQsHf8c2pbN92F1gUY3sJkpW3ZJFzdmfbAJPAXT5aw3');
+  var sec = crypto.PrivateKey.from('5JamTPvZyQsHf8c2pbN92F1gUY3sJkpW3ZJFzdmfbAJPAXT5aw3');
   var pub = crypto.PublicKey.from('STM5SKxjN1YdrFLgoPcp9KteUmNVdgE8DpTPC9sF6jbjVqP9d2Utq');
 
   var failures = [];


### PR DESCRIPTION
This PR introduces the concept of signatures from which the public key can be recovered (just requires a special header byte to be set). This is the way bitcoin serializes signatures and we need to replicate this behavior.

If you just want the plain old `(r, s)` of the signature all you have to do is slice the first byte off. Nothing else is different.

I've also added the `PublicKey.recover(hash, signature)` method, which re-obtains the canonical public key from (hash, signature).