### PR TITLE
rename SecretKey to PrivateKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ ArrayBuffer { byteLength: 20 }
 '9c1185a5c5e9fc54612808977ee8f548b2258d31'
 ```
 
-### crypto.SecretKey
+### crypto.PrivateKey
 
 Provides operations over Steemit secp256k1-based ECC private keys.
 ```
-> secretKey = crypto.SecretKey.from('5JCDRqLdyX4W7tscyzyxav8EaqABSVAWLvfi7rdqMKJneqqwQGt')
-SecretKey { getPublicKey: [Function], sign: [Function] }
+> secretKey = crypto.PrivateKey.from('5JCDRqLdyX4W7tscyzyxav8EaqABSVAWLvfi7rdqMKJneqqwQGt')
+PrivateKey { getPublicKey: [Function], sign: [Function] }
 > secretKey.getPublicKey().toString()
 'STM5pZ15FDVAvNKW3saTJchWmSSmYtEvA6aKiXwDtCq2JRZV9KtR9'
 > secretSig = secretKey.sign(new Uint8Array(32).buffer)

--- a/src/codecSteemit.js
+++ b/src/codecSteemit.js
@@ -42,14 +42,14 @@ sjcl.codec.steemit = {
     );
   },
 
-  serializeSecretKey: function(key, header) {
+  serializePrivateKey: function(key, header) {
     return sjcl.codec.base58Check.fromBits(
       header || sjcl.codec.steemit.HEADER,
       key.get()
     );
   },
 
-  deserializeSecretKey: function(wif, header) {
+  deserializePrivateKey: function(wif, header) {
     header = header || sjcl.codec.steemit.HEADER;
     var curve = sjcl.ecc.curves.k256;
     var payload = sjcl.codec.base58Check.toBits(wif);

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -9,7 +9,7 @@
     factory((root.steemit.crypto = {}));
   }
 })(typeof self !== 'undefined' ? self : this, function(exports) {
-  exports.SecretKey = SecretKey;
+  exports.PrivateKey = PrivateKey;
   exports.PublicKey = PublicKey;
   exports.generateKeys = generateKeys;
   exports.keysFromPassword = keysFromPassword;
@@ -24,7 +24,7 @@
     return sjcl;
   })();
 
-  function SecretKey(sec, pub) {
+  function PrivateKey(sec, pub) {
     // we deliberately avoid exposing secret key material on the instance.
     // this is paranoid and probably doesn't protect against a determined
     // attack, but why make things easy?
@@ -44,8 +44,8 @@
     };
   }
 
-  SecretKey.from = function(wif, header) {
-    return new SecretKey(sjcl.codec.steemit.deserializeSecretKey(wif, header));
+  PrivateKey.from = function(wif, header) {
+    return new PrivateKey(sjcl.codec.steemit.deserializePrivateKey(wif, header));
   };
 
   function PublicKey(pub) {
@@ -110,7 +110,7 @@
 
   function serializePair(k) {
     return {
-      secret: sjcl.codec.steemit.serializeSecretKey(k.sec),
+      secret: sjcl.codec.steemit.serializePrivateKey(k.sec),
       public: sjcl.codec.steemit.serializePublicKey(k.pub)
     };
   }

--- a/test/codecSteemit.test.js
+++ b/test/codecSteemit.test.js
@@ -16,7 +16,7 @@ new sjcl.test.TestCase("steemit key codec tests", function (cb) {
       testValue.password
     );
 
-    var serializedSec = sjcl.codec.steemit.serializeSecretKey(keys[testValue.role].sec);
+    var serializedSec = sjcl.codec.steemit.serializePrivateKey(keys[testValue.role].sec);
     var serializedPub = sjcl.codec.steemit.serializePublicKey(keys[testValue.role].pub);
 
     this.require(testValue.sec == serializedSec, 'secret key: generated ' + serializedSec + ', expected ' + testValue.sec);
@@ -40,10 +40,10 @@ new sjcl.test.TestCase("steemit key codec tests", function (cb) {
     );
 
     // on deserialization the secret key should be the same
-    var deserializedSecretKey = sjcl.codec.steemit.deserializeSecretKey(serializedSec);
+    var deserializedPrivateKey = sjcl.codec.steemit.deserializePrivateKey(serializedSec);
     this.require(
       sjcl.bitArray.equal(
-        deserializedSecretKey.get(),
+        deserializedPrivateKey.get(),
         keys[testValue.role].sec.get()
       ),
       "original and deserialized secret keys are identical"

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -23,7 +23,7 @@ test('crypto.generateKeys', function(t) {
 
   t.equal(keys.public.slice(0, 3), 'STM', 'generated public key is in steem format');
 
-  var sec = crypto.SecretKey.from(keys.secret);
+  var sec = crypto.PrivateKey.from(keys.secret);
   var pub = crypto.PublicKey.from(keys.public);
 
   var sig = sec.sign(testHash);
@@ -65,8 +65,8 @@ test('crypto.keysFromPassword', function(t) {
 });
 
 
-test('crypto.SecretKey', function(t) {
-  var sec = crypto.SecretKey.from('5JamTPvZyQsHf8c2pbN92F1gUY3sJkpW3ZJFzdmfbAJPAXT5aw3');
+test('crypto.PrivateKey', function(t) {
+  var sec = crypto.PrivateKey.from('5JamTPvZyQsHf8c2pbN92F1gUY3sJkpW3ZJFzdmfbAJPAXT5aw3');
   t.equal(
     sec.getPublicKey().toString(),
     'STM5SKxjN1YdrFLgoPcp9KteUmNVdgE8DpTPC9sF6jbjVqP9d2Utq',
@@ -86,7 +86,7 @@ test('crypto.SecretKey', function(t) {
 });
 
 test('crypto.PublicKey', function(t) {
-  var sec = crypto.SecretKey.from('5JamTPvZyQsHf8c2pbN92F1gUY3sJkpW3ZJFzdmfbAJPAXT5aw3');
+  var sec = crypto.PrivateKey.from('5JamTPvZyQsHf8c2pbN92F1gUY3sJkpW3ZJFzdmfbAJPAXT5aw3');
   var pub = crypto.PublicKey.from('STM5SKxjN1YdrFLgoPcp9KteUmNVdgE8DpTPC9sF6jbjVqP9d2Utq');
 
   var failures = [];


### PR DESCRIPTION
Closes #3.

Does what it says on the tin. Apparently `PrivateKey` is the name we use elsewhere, far be it from me to diverge from convention.